### PR TITLE
TimescaleDB

### DIFF
--- a/crypto_hft/data_layer/database.py
+++ b/crypto_hft/data_layer/database.py
@@ -19,8 +19,6 @@ DB_CONFIG = {
 
 BASE_TICKERS = config.base_tickers  # Access through the instance
 
-from itertools import product
-
 def create_order_book_table(symbol):
     '''query to create order_book_table'''
     table_name = f"orderbook_{symbol.upper().replace('-', '_')}"
@@ -32,8 +30,7 @@ def create_order_book_table(symbol):
     query = f"""
         CREATE TABLE IF NOT EXISTS {table_name} (
             id INT AUTO_INCREMENT PRIMARY KEY,
-            exchange VARCHAR(255) NOT NULL,
-            symbol VARCHAR(255) NOT NULL,
+            exchange VARCHAR(25) NOT NULL,
             timestamp DATETIME(6) NOT NULL,
             local_timestamp DATETIME(6) NOT NULL, 
             {', '.join(price_cols)}
@@ -49,16 +46,15 @@ def create_trade_table(symbol):
     query = f"""
         CREATE TABLE IF NOT EXISTS {table_name} (
             id INT AUTO_INCREMENT PRIMARY KEY,
-            exchange VARCHAR(255) NOT NULL,
-            symbol VARCHAR(255) NOT NULL,
+            exchange VARCHAR(25) NOT NULL,
             trade_id VARCHAR(255) UNIQUE NOT NULL,
             price DECIMAL(20,10) NOT NULL,  
             amount DECIMAL(20,10) NOT NULL, 
-            side VARCHAR(255) NOT NULL,
+            side ENUM('buy', 'sell') NOT NULL,
             timestamp DATETIME(6) NOT NULL,
             local_timestamp DATETIME(6) NOT NULL
         );
-    """
+    """ # todo trade_id should be an integer
     return query
 
 

--- a/crypto_hft/data_layer/db_writer.py
+++ b/crypto_hft/data_layer/db_writer.py
@@ -101,7 +101,7 @@ class QueueProcessor:
 
     async def process_order_book_queue(self, symbol: str, queue: asyncio.Queue):
         """Processes a single order book queue."""
-        columns = ["exchange", "symbol", "timestamp", "local_timestamp"] + [
+        columns = ["exchange", "timestamp", "local_timestamp"] + [
             f"bid_{i}_sz" for i in range(self.config.orderbook_levels)
         ] + [
             f"bid_{i}_px" for i in range(self.config.orderbook_levels)
@@ -114,7 +114,7 @@ class QueueProcessor:
 
     async def process_trade_queue(self, symbol: str, queue: asyncio.Queue):
         """Processes a single trade queue."""
-        columns = ["exchange", "symbol", "trade_id", "price", "amount", "side", "timestamp", "local_timestamp"]
+        columns = ["exchange", "trade_id", "price", "amount", "side", "timestamp", "local_timestamp"]
         await self.process_queue(symbol, queue, "trade", columns)
 
     async def batch_insert_order_books(self):


### PR DESCRIPTION
### Overview

* Removed `symbol` and made `exchange` a `VARCHAR(25)` for both trades and OB schema
* Changed `side` to `ENUM('buy', 'sell') for trades schema
* Removed `symbol` from the list of columns in `process_trade_queue`,`process_order_book_queue`

### TODOs
* Pretty sure `trade_id` could be made a long to avoid using the varchar (below screen from a sample trades table)
* Need to change the functions to use TimescaleDB
* Need to check types if we switch to PSQL

<img width="725" alt="Screenshot 2025-03-21 at 1 48 05 PM" src="https://github.com/user-attachments/assets/5082b50d-f1b9-4b21-bd95-4c9df7fa43b1" />
